### PR TITLE
pylint

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -208,7 +208,7 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
             if dt is None:
                 if by_field_name:
                     return [(create_array(s[field.name], field.type), field.name) for field in t]
-                else: 
+                else:
                     return [
                         (create_array(s[s.columns[i]], field.type), field.name)
                         for i, field in enumerate(t)
@@ -221,7 +221,8 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
                     ]
                 else:
                     return [
-                        (create_array(s[s.columns[i]], field.type, struct_field.dataType), field.name)
+                        (create_array(s[s.columns[i]], field.type, struct_field.dataType),
+                         field.name)
                         for i, (field, struct_field) in enumerate(zip(t, dt.fields))
                     ]
 

--- a/python/pyspark/testing/sqlutils.py
+++ b/python/pyspark/testing/sqlutils.py
@@ -22,7 +22,7 @@ import tempfile
 from contextlib import contextmanager
 
 from pyspark.sql import SparkSession
-from pyspark.sql.types import ArrayType, DoubleType, TimestampType, StructField, StructType, \
+from pyspark.sql.types import ArrayType, DoubleType, StructField, StructType, \
     UserDefinedType, Row
 from pyspark.testing.utils import ReusedPySparkTestCase
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
Make pylint happy for https://github.com/apache/spark/pull/31735


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
```
dev/lint-python
```

pip freeze:
```
certifi==2020.12.5
coverage==5.5
flake8==3.9.0
mccabe==0.6.1
numpy==1.20.1
pandas==1.2.3
pyarrow==2.0.0
pycodestyle==2.7.0
pyflakes==2.3.0
python-dateutil==2.8.1
pytz==2021.1
scipy==1.6.1
six==1.15.0
xmlrunner==1.7.7
```
